### PR TITLE
Use enter key instead of space for A button

### DIFF
--- a/Quake-iOS/GameControllerSetup.swift
+++ b/Quake-iOS/GameControllerSetup.swift
@@ -57,7 +57,7 @@ class GameControllerSetup: NSObject
                 
                 remote!.extendedGamepad!.buttonA.pressedChangedHandler = { (button: GCControllerButtonInput, value: Float, pressed: Bool) -> () in
                     
-                        Sys_Key_Event(32, qboolean(pressed ? 1 : 0)) // K_ENTER, true / false
+                    Sys_Key_Event(13, qboolean(pressed ? 1 : 0)) // K_ENTER, true / false
 
                 }
                 


### PR DESCRIPTION
This pull request replaces the A button key code, `K_ENTER` is used instead of `K_SPACE` to align with the iOS controller overlay. This also fixes the menu when using a controller.

It appears that the [original code](https://github.com/Izhido/Quake_For_OSX/blob/1d7bc2b4416f412edccb741b29060386f0eb27c7/Quake_iOS_VR/GameControllerSetup.swift#L62) also used  `K_ENTER`, which is indicated by the left over comment.