### PR TITLE
Add ability to invert controller Y-axis

### DIFF
--- a/Quake-iOS/GameControllerSetup.swift
+++ b/Quake-iOS/GameControllerSetup.swift
@@ -90,9 +90,13 @@ class GameControllerSetup: NSObject
                 }
                 
                 remote!.extendedGamepad!.rightThumbstick.yAxis.valueChangedHandler = { (button: GCControllerAxisInput, value: Float) -> () in
-                    
-                    in_pitchangle = -value
-                    
+
+                    if m_pitch.value > 0 {
+                        in_pitchangle = -value
+                    } else {
+                        in_pitchangle = value
+                    }
+
                 }
                 
                 remote!.extendedGamepad!.rightTrigger.pressedChangedHandler = { (button: GCControllerButtonInput, value: Float, pressed: Bool) -> () in


### PR DESCRIPTION
This pull request allows the controller to be inverted depending on the settings.

If the value of `m_pitch` in `config.cfg` is `-0.022000` the mouse will be inverted and if the value is `0.022000` it will not be. The "Invert Mouse" value in settings can also be used.